### PR TITLE
Fix release script and docs republish action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: redeploy docs
-    runs-on: ubuntu latest
+    runs-on: ubuntu-latest
 
     steps:
       - run: curl -X POST -d {} $AHKPM_DEV_BUILD_HOOK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed a bug where the local package cache was taking precedence over the remote
 - `ahkpm version` now also attempts to display the version of AutoHotkey installed
 - Set up a new documentation site at [ahkpm.dev][https://ahkpm.dev].
+
 ## 0.3.0
 
 - Resolve transitive dependencies

--- a/magefile.go
+++ b/magefile.go
@@ -77,7 +77,7 @@ func VerifyVersion(version string) error {
 		return err
 	}
 
-	if !strings.Contains(out, "ahkpm version: "+version) {
+	if !strings.Contains(out, version) {
 		return errors.New("Version mismatch.\n    Expected: " + version + "\n    Actual: " + out)
 	}
 


### PR DESCRIPTION
The release script no longer worked after `ahkpm version`'s output changed.

The docs republish action was waiting forever for "ubuntu latest" when it should have been "ubuntu-latest".