### PR TITLE
Issue124: ahkpm update support a --all flag

### DIFF
--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -10,6 +10,7 @@ import (
 
 //go:embed update-long.md
 var updateLong string
+var all bool
 
 var updateCmd = &cobra.Command{
 	Use:        "update <packageName>...",
@@ -18,6 +19,16 @@ var updateCmd = &cobra.Command{
 	Long:       updateLong,
 	Example:    "ahkpm update github.com/joshuacc/fake-package\nahkpm update gh:joshuacc/fake-package",
 	Run: func(cmd *cobra.Command, args []string) {
+		deps := core.ManifestFromCwd().Dependencies
+		packages := GetDependencies(deps)
+		if all {
+			installer := core.Installer{}
+			err := installer.Update(packages...)
+			if err != nil {
+				fmt.Println(err.Error())
+			}
+			return
+		}
 		if len(args) == 0 {
 			fmt.Println("Please specify a package name")
 			return
@@ -30,6 +41,15 @@ var updateCmd = &cobra.Command{
 	},
 }
 
+func GetDependencies(set core.DependencySet) []string {
+	var allPackages []string
+	for _, dep := range set.AsArray() {
+		allPackages = append(allPackages, dep.Name())
+	}
+	return allPackages
+}
+
 func init() {
+	updateCmd.Flags().BoolVar(&all, "all", false, "updates all dependencies")
 	RootCmd.AddCommand(updateCmd)
 }

--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -10,7 +10,6 @@ import (
 
 //go:embed update-long.md
 var updateLong string
-var all bool
 
 var updateCmd = &cobra.Command{
 	Use:        "update <packageName>...",
@@ -19,9 +18,9 @@ var updateCmd = &cobra.Command{
 	Long:       updateLong,
 	Example:    "ahkpm update github.com/joshuacc/fake-package\nahkpm update gh:joshuacc/fake-package",
 	Run: func(cmd *cobra.Command, args []string) {
-		deps := core.ManifestFromCwd().Dependencies
-		packages := GetDependencies(deps)
-		if all {
+		if cmd.Flag("all").Value.String() == "true" {
+			deps := core.ManifestFromCwd().Dependencies
+			packages := GetDependencies(deps)
 			installer := core.Installer{}
 			err := installer.Update(packages...)
 			if err != nil {
@@ -50,6 +49,6 @@ func GetDependencies(set core.DependencySet) []string {
 }
 
 func init() {
-	updateCmd.Flags().BoolVar(&all, "all", false, "updates all dependencies")
+	updateCmd.Flags().BoolP("all", "a", false, "Updates all dependencies and not recommended unless you have your script in version control")
 	RootCmd.AddCommand(updateCmd)
 }


### PR DESCRIPTION
Addressing[ Issue124](https://github.com/joshuacc/ahkpm/issues/124) so `ahkpm update` supports a `--all` or `-a` flag to update all dependencies at once.