### PR TITLE
Remove extraneous name field in ahkpm.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ This file is where the user of ahkpm declares their dependencies and other packa
 
 ```jsonc
 {
-  "name": "my-project",
   "version": "0.0.1",
   "description": "A brief description of what the package does",
   // URL for the package's git repository

--- a/src/cmd/init.go
+++ b/src/cmd/init.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/mail"
 	"net/url"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -37,29 +36,13 @@ var initCmd = &cobra.Command{
 			utils.Exit("ahkpm.json already exists in this directory")
 		}
 
-		cwd, err := os.Getwd()
-		if err != nil {
-			fmt.Println("Unable to get current working directory")
-			return
-		}
-		cwd = filepath.Base(cwd)
-		cwd = strings.ToLower(cwd)
-		cwd = strings.Replace(cwd, " ", "-", -1)
-
 		// Initialize with default values
 		manifest := core.NewManifest()
-		manifest.Name = cwd
 		manifest.Version = "0.0.1"
 		manifest.License = "MIT"
 		manifest.Include = getDefaultInclude()
 
 		for {
-			manifest.Name = showPrompt(
-				"What is the name of your package?",
-				validateNothing,
-				prompt.OptionInitialBufferText(manifest.Name),
-			)
-
 			manifest.Version = showPrompt(
 				"What version is the package? (Using semantic versioning)",
 				validateSemver,

--- a/src/core/manifest.go
+++ b/src/core/manifest.go
@@ -8,7 +8,6 @@ import (
 
 // Manifest contains the data from ahkpm.json
 type Manifest struct {
-	Name         string        `json:"name"`
 	Version      string        `json:"version"`
 	Description  string        `json:"description"`
 	Repository   string        `json:"repository"`

--- a/src/core/manifest_test.go
+++ b/src/core/manifest_test.go
@@ -17,7 +17,6 @@ func TestNewManifest(t *testing.T) {
 
 func TestMarshalJSON(t *testing.T) {
 	m := NewManifest()
-	m.Name = "ahkpm"
 	m.Version = "0.0.1"
 	m.Description = "A package manager for AutoHotkey"
 	m.Repository = "https://github.com/ahkpm/ahkpm"
@@ -35,7 +34,6 @@ func TestMarshalJSON(t *testing.T) {
 	assert.Nil(t, err)
 
 	expected := `{
-		"name": "ahkpm",
 		"version": "0.0.1",
 		"description": "A package manager for AutoHotkey",
 		"repository": "https://github.com/ahkpm/ahkpm",


### PR DESCRIPTION
Because the actual name for any package is the url at which it can be found, the name field in ahkpm.json is both redundant and potentially confusing. This commit removes it.

Fixes #133