### PR TITLE
Switch scripts runner from cmd.exe to pwsh.exe

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -39,7 +39,7 @@ func RunScript(scriptName string) {
 
 	fmt.Println("> " + script)
 
-	scriptCmd := exec.Command("cmd", "/c", script)
+	scriptCmd := exec.Command("pwsh", "-c", script)
 
 	// Allow the script to use the current program's stdin, stdout, and stderr
 	scriptCmd.Stdout = os.Stdout


### PR DESCRIPTION
This minimizes the number of weird things that occur when using commands like echo.