### PR TITLE
Switch `ahkpm init`'s default version to 1.0.0

### DIFF
--- a/src/core/initializer.go
+++ b/src/core/initializer.go
@@ -221,7 +221,7 @@ func makeOptional(validator Validator) Validator {
 func GetNewManifestWithDefaults() *Manifest {
 	manifest := NewManifest()
 
-	manifest.Version = "0.0.1"
+	manifest.Version = "1.0.0"
 	manifest.Include = getDefaultInclude()
 	manifest.Repository = getDefaultRepository()
 	manifest.Website = manifest.Repository

--- a/src/core/initializer_test.go
+++ b/src/core/initializer_test.go
@@ -11,7 +11,7 @@ func TestGetNewManifestWithDefaults(t *testing.T) {
 	m := GetNewManifestWithDefaults()
 
 	assert.IsType(t, &Manifest{}, m)
-	assert.Equal(t, "0.0.1", m.Version)
+	assert.Equal(t, "1.0.0", m.Version)
 	assert.Equal(t, "", m.Description)
 	assert.Equal(t, "", m.Include)
 	assert.Equal(t, "MIT", m.License)


### PR DESCRIPTION
To avoid ecosystem issues with packages staying at 0.x.x when it's not warranted.